### PR TITLE
test on more OSs

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,10 +15,4 @@ galaxy_info:
       versions:
         - 7
         - 8
-    - name: Debian
-      versions:
-        - all
-    - name: Ubuntu
-      versions:
-        - all
 dependencies: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,4 +15,10 @@ galaxy_info:
       versions:
         - 7
         - 8
+    - name: Debian
+      versions:
+        - stable
+    - name: Ubuntu
+      versions:
+        - focal
 dependencies: []

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -1,0 +1,8 @@
+FROM {{ item.image }}
+
+# Install dependencies
+{% if "centos" in item.name %}
+RUN dnf install --refresh -y sudo systemd bash ca-certificates iproute python39 python3-libselinux
+{% else %}
+RUN apt-get update && apt-get install -y python sudo bash ca-certificates iproute2 init python3 && apt-get clean
+{% endif %}

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -5,9 +5,18 @@ dependency:
 driver:
   name: podman
 platforms:
-  - name: opencast-nginx-centos
-    image: docker.io/pycontribs/centos:8
-    pre_build_image: true
+  - name: opencast-nginx-centos8
+    image: quay.io/centos/centos:stream8
+    pre_build_image: false
+    command: /sbin/init
+    tmpfs:
+      - /run
+      - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  - name: opencast-nginx-centos9
+    image: quay.io/centos/centos:stream9
+    pre_build_image: false
     command: /sbin/init
     tmpfs:
       - /run

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -23,6 +23,26 @@ platforms:
       - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  - name: opencast-nginx-debian
+    image: docker.io/debian:stable
+    pre_build_image: false
+    privileged: true
+    command: /sbin/init
+    tmpfs:
+      - /run
+      - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  - name: opencast-nginx-ubuntu
+    image: docker.io/ubuntu:20.04
+    pre_build_image: false
+    privileged: true
+    command: /sbin/init
+    tmpfs:
+      - /run
+      - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
 lint: |
   set -e
   yamllint .

--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -1,7 +1,11 @@
 #jinja2:lstrip_blocks: True
 # Defines user and group credentials used by worker processes. If group is
 # omitted, a group whose name equals that of user is used.
-user nginx;
+{% if ansible_os_family == 'Debian' %}
+user    www-data;
+{% else %}
+user    nginx;
+{% endif %}
 
 # Defines the number of worker processes.    Setting it to the number of
 # available CPU cores should be a good start. The value `auto` will try to


### PR DESCRIPTION
The tests for CentOS Linux 8 are deprecated. This now tests onStream 8 &  9. 

~~It also removes the support for Debian-family OSs in the role meta-data (because they are not supported by this role).~~

This also adapts the role to work and test on debian and ubuntu.