### PR TITLE
CORS nginx configuration fixed

### DIFF
--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -90,6 +90,21 @@ http {
     location /protected {
       internal;
       alias {{ opencast_storage_downloads_path }};
+
+      # CORS configuration
+      {% if opencast_cors_urls %}
+      add_header Access-Control-Allow-Origin       '$cors_origin';
+      add_header Access-Control-Allow-Credentials  '$cors_credentials';
+      {% else %}
+      add_header Access-Control-Allow-Origin       '$http_origin';
+      add_header Access-Control-Allow-Credentials  'true';
+      {% endif %}
+      add_header Access-Control-Allow-Methods 'GET, OPTIONS' always;
+      add_header Access-Control-Allow-Headers 'Origin,Content-Type,Accept,Authorization' always;
+
+      if ($request_method = OPTIONS) {
+        return 200;
+      }
     }
 
     # Proxy configuration for Opencast
@@ -115,17 +130,20 @@ http {
       # Do not buffer requests
       proxy_request_buffering off;
 
-      {% if opencast_cors_urls %}
       # CORS configuration
+      {% if opencast_cors_urls %}
       add_header Access-Control-Allow-Origin       '$cors_origin';
       add_header Access-Control-Allow-Credentials  '$cors_credentials';
+      {% else %}
+      add_header Access-Control-Allow-Origin       '$http_origin';
+      add_header Access-Control-Allow-Credentials  'true';
+      {% endif %}
       add_header Access-Control-Allow-Methods 'GET, POST, OPTIONS' always;
       add_header Access-Control-Allow-Headers 'Origin,Content-Type,Accept,Authorization' always;
 
       if ($request_method = OPTIONS) {
         return 200;
       }
-      {% endif %}
     }
 
     # Include additional custom configuration


### PR DESCRIPTION
CORS headers are requider for use Opencast standalone editor at least. Otherwise the waveform generation will fail.