### PR TITLE
Use default modules config path on debian based systems

### DIFF
--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -20,7 +20,11 @@ error_log /var/log/nginx/error.log;
 pid /run/nginx.pid;
 
 # Load dynamic modules. See /usr/share/nginx/README.dynamic.
+{% if ansible_os_family == 'Debian' %}
+include /etc/nginx/modules-enabled/*.conf;
+{% else %}
 include /usr/share/nginx/modules/*.conf;
+{% endif %}
 
 events {
   # Sets the maximum number of simultaneous connections that can be opened by


### PR DESCRIPTION
Default Nginx modules configuration path is /etc/nginx/modules-enabled/ on debian based systems. All *.conf files there are linked to /usr/share/nginx/modules-available/. We should respect this in the nginx configuration.

```
root@3a4203d78897:/# ls -la /etc/nginx/modules-enabled/
total 20
drwxr-xr-x. 2 root root 4096 Jan  8 17:05 .
drwxr-xr-x. 8 root root 4096 Jan  8 17:03 ..
lrwxrwxrwx. 1 root root   57 Jan  8 17:05 50-mod-http-auth-pam.conf -> /usr/share/nginx/modules-available/mod-http-auth-pam.conf
lrwxrwxrwx. 1 root root   56 Jan  8 17:05 50-mod-http-dav-ext.conf -> /usr/share/nginx/modules-available/mod-http-dav-ext.conf
lrwxrwxrwx. 1 root root   53 Jan  8 17:05 50-mod-http-echo.conf -> /usr/share/nginx/modules-available/mod-http-echo.conf
lrwxrwxrwx. 1 root root   55 Jan  8 17:05 50-mod-http-geoip2.conf -> /usr/share/nginx/modules-available/mod-http-geoip2.conf
lrwxrwxrwx. 1 root root   60 Jan  8 17:05 50-mod-http-subs-filter.conf -> /usr/share/nginx/modules-available/mod-http-subs-filter.conf
lrwxrwxrwx. 1 root root   62 Jan  8 17:05 50-mod-http-upstream-fair.conf -> /usr/share/nginx/modules-available/mod-http-upstream-fair.conf
lrwxrwxrwx. 1 root root   50 Jan  8 17:03 50-mod-stream.conf -> /usr/share/nginx/modules-available/mod-stream.conf
lrwxrwxrwx. 1 root root   57 Jan  8 17:05 70-mod-stream-geoip2.conf -> /usr/share/nginx/modules-available/mod-stream-geoip2.conf
```