### PR TITLE
Fixed molecule tests

### DIFF
--- a/.dev_requirements.txt
+++ b/.dev_requirements.txt
@@ -4,5 +4,6 @@ ansible-lint
 dnspython
 yamllint
 molecule
-molecule-docker
-molecule-podman
+molecule-plugins
+molecule-plugins[docker]
+molecule-plugins[podman]

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -17,6 +17,6 @@ jobs:
         run: pip3 install -r .dev_requirements.txt
 
       - name: test playbook
-        run: molecule test --driver-name docker
+        run: molecule test
         env:
           PY_COLORS: '1'

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,12 +13,15 @@ galaxy_info:
   platforms:
     - name: EL
       versions:
-        - 7
         - 8
+        - 9
     - name: Debian
       versions:
         - bullseye
+        - bookworm
     - name: Ubuntu
       versions:
         - focal
+        - jammy
+        - noble
 dependencies: []

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -4,5 +4,5 @@ FROM {{ item.image }}
 {% if "centos" in item.name %}
 RUN dnf install --refresh -y sudo systemd bash ca-certificates iproute python39 python3-libselinux
 {% else %}
-RUN apt-get update && apt-get install -y python sudo bash ca-certificates iproute2 init python3 && apt-get clean
+RUN apt-get update && apt-get install -y sudo init bash ca-certificates iproute2 python3 && apt-get clean
 {% endif %}

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -3,44 +3,33 @@ dependency:
   name: galaxy
   enabled: false
 driver:
-  name: podman
+  name: containers
 platforms:
-  - name: opencast-nginx-centos8
-    image: quay.io/centos/centos:stream8
-    pre_build_image: false
-    command: /sbin/init
-    tmpfs:
-      - /run
-      - /tmp
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - name: opencast-nginx-centos9
     image: quay.io/centos/centos:stream9
     pre_build_image: false
     command: /sbin/init
     tmpfs:
-      - /run
-      - /tmp
+      "/tmp": "exec"
+      "/run": "rw,noexec,nosuid,nodev"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - name: opencast-nginx-debian
     image: docker.io/debian:stable
     pre_build_image: false
-    privileged: true
     command: /sbin/init
     tmpfs:
-      - /run
-      - /tmp
+      "/tmp": "exec"
+      "/run": "rw,noexec,nosuid,nodev"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - name: opencast-nginx-ubuntu
-    image: docker.io/ubuntu:20.04
+    image: docker.io/ubuntu:latest
     pre_build_image: false
-    privileged: true
     command: /sbin/init
     tmpfs:
-      - /run
-      - /tmp
+      "/tmp": "exec"
+      "/run": "rw,noexec,nosuid,nodev"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
 lint: |


### PR DESCRIPTION
Using Molecule driver containers fixes tests on systems with docker and podman installed. Deprecated and EOL container images are dropped.

closes #6