### PR TITLE
Ansible role properities should be prefixed with role name

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ to generate Diffie-Hellman parameters. You therefor need to have the [community.
 Role Variables
 --------------
 
-- `opencast_storage_downloads_path`
+- `opencast_nginx_storage_downloads_path`
     - Path to Opencast's downloads directory (default: `/srv/opencast/downloads/`)
-- `opencast_cors_urls`
+- `opencast_nginx_cors_urls`
     - List of URLs to add CORS exceptions for (default: `[]`)
 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-opencast_cors_urls: []
-opencast_storage_downloads_path: /srv/opencast/downloads/
+opencast_nginx_cors_urls: []
+opencast_nginx_storage_downloads_path: /srv/opencast/downloads/

--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -56,12 +56,12 @@ http {
     }
   }
 
-  {% if opencast_cors_urls %}
+  {% if opencast_nginx_cors_urls %}
   map_hash_bucket_size 128;
 
   map $http_origin $cors_ok {
     default       0;
-    {% for url in opencast_cors_urls %}
+    {% for url in opencast_nginx_cors_urls %}
     {{ url }}     1;
     {% endfor %}
   }
@@ -93,10 +93,10 @@ http {
 
     location /protected {
       internal;
-      alias {{ opencast_storage_downloads_path }};
+      alias {{ opencast_nginx_storage_downloads_path }};
 
       # CORS configuration
-      {% if opencast_cors_urls %}
+      {% if opencast_nginx_cors_urls %}
       add_header Access-Control-Allow-Origin       '$cors_origin';
       add_header Access-Control-Allow-Credentials  '$cors_credentials';
       {% else %}
@@ -135,7 +135,7 @@ http {
       proxy_request_buffering off;
 
       # CORS configuration
-      {% if opencast_cors_urls %}
+      {% if opencast_nginx_cors_urls %}
       add_header Access-Control-Allow-Origin       '$cors_origin';
       add_header Access-Control-Allow-Credentials  '$cors_credentials';
       {% else %}


### PR DESCRIPTION
Ansible linter give you a warning about properties not prefixed with role name. This PR should address this issue.