### PR TITLE
Allow additional vhosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,12 @@ If you want to use Let's Encrypt to generate certificates, you can also include 
 [`elan.opencast_certbot`](https://galaxy.ansible.com/elan/opencast_certbot)
 which will automatically generate TLS certificates for you.
 
-
 You can also add some custom configuration in the file `/etc/nginx/conf.d/extra.conf`.
 The file is included after Opencast's main `location` block.
 The role will not modify this file if it exists.
+
+Additionally you can define other virtual hosts in `/etc/nginx/sites-enabled/` directory.
+They will be loaded as well.
 
 
 Example Playbook
@@ -72,7 +74,7 @@ The role will _not_ replace an existing certificate so you can safely use a `fil
         owner: root
         group: root
         mode: '0400'
-      notify: reload nginx
+      notify: Reload nginx
       loop:
         - key
         - crt

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ The role will not modify this file if it exists.
 Additionally you can define other virtual hosts in `/etc/nginx/sites-enabled/` directory.
 They will be loaded as well.
 
+> ℹ️ You may want to disable Nginx default vhost on Debian based systems by removing the
+  `/etc/nginx/sites-enabled/default` symlink.
+
 
 Example Playbook
 ----------------

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -6,13 +6,13 @@
   tasks:
     - name: Test that nginx redirects to https
       ansible.builtin.uri:
-        url: http://127.0.0.1/
+        url: http://{{ inventory_hostname }}/
         follow_redirects: none
         status_code: 301
 
     - name: Test that nginx acts as proxy on https
       ansible.builtin.uri:
-        url: https://127.0.0.1/
+        url: https://{{ inventory_hostname }}/
         validate_certs: false
         follow_redirects: none
         status_code: 502
@@ -30,7 +30,7 @@
 
     - name: Test extra configuration
       ansible.builtin.uri:
-        url: https://127.0.0.1/test
+        url: https://{{ inventory_hostname }}/test
         validate_certs: false
         follow_redirects: none
         status_code: 204

--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -153,4 +153,7 @@ http {
     # Include additional custom configuration
     include /etc/nginx/conf.d/extra.conf;
   }
+
+  # Include dynamic virtual host configurations
+  include /etc/nginx/sites-enabled/*;
 }


### PR DESCRIPTION
Since Opencast 16+ requires OpenSearch on the admin and presentation nodes, we should provide an option to create a virtual host for this purpose. With this patch all additional vhost configurations from /etc/nginx/sites-enabled/ will be loaded.