### PR TITLE
Add `Vary` header for correct fixing of CORS headers

### DIFF
--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -142,6 +142,9 @@ http {
       add_header Access-Control-Allow-Origin       '$http_origin';
       add_header Access-Control-Allow-Credentials  'true';
       {% endif %}
+      # Correct browser caching, see 
+      # https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin#cors_and_caching
+      add_header Vary 'Origin' always; 
       add_header Access-Control-Allow-Methods 'GET, POST, OPTIONS' always;
       add_header Access-Control-Allow-Headers 'Origin,Content-Type,Accept,Authorization' always;
 


### PR DESCRIPTION
When the server's `Access-Control-Allow-Origin` header depends on the incoming `Origin` header, then the server should also set `Vary: Origin`. Otherwise, browsers are allowed to cache the response (made from one origin) and use it when another origin requests the same file. But then the `Allow-Origin` does not match the second one, leading to a CORS error. With this header, the browser must cache the response separately for each origin. This of course has some disadvantages, as there will be more cache misses. It's not ideal, but the previous config can lead to very broken behavior in some situations.

As an aside: if I understand the config correctly, if `opencast_nginx_cors_urls` are not set, then the cors headers always say "allow" to whatever origin. Is that really intended? Seems potentially dangerous that leaving away this config value opens up CORS to everyone.